### PR TITLE
Implement custom trim strategies

### DIFF
--- a/src/pgmap/cli.py
+++ b/src/pgmap/cli.py
@@ -48,10 +48,11 @@ def _parse_args(args: list[str]) -> argparse.Namespace:
                         help="Output file path to populate with the counts for each paired guide and sample. If not provided the counts will be output in STDOUT.")
     parser.add_argument("--trim-strategy", required=True, type=_check_trim_strategy,
                         help="The trim strategy used to extract guides and barcodes. " +
-                             "A custom trim strategy should be formatted as as space separate list of trim coordinates for gRNA1, gRNA2, and the barcode. " +
+                             "A custom trim strategy should be formatted as as comma separate list of trim coordinates for gRNA1, gRNA2, and the barcode. " +
                              "Each trim coordinate should contain three zero indexed integers giving the file index relative to the order provided in --fastq, " +
                              "the inclusive start index of the trim, and the exclusive end index of the trim. " +
-                             "For convenience the options \"two-read\" and \"three-read\" map to default values \"0:0:20 1:1:21 1:160:166\" and \"0:0:20 1:1:21 2:0:6\" respectively. " +
+                             "The indices within the trim coordinate should be separated by colon. " +
+                             "For convenience the options \"two-read\" and \"three-read\" map to default values \"0:0:20,1:1:21,1:160:166\" and \"0:0:20,1:1:21,2:0:6\" respectively. " +
                              "The two read strategy should have fastqs R1 and I1. " +
                              "The three read strategy should have fastqs R1, I1, and I2.")
     parser.add_argument("--gRNA1-error", required=False, default=1, type=_check_gRNA1_error,
@@ -110,7 +111,7 @@ def _check_trim_strategy(serialized_trim_strategy: str) -> TrimStrategy:
     elif serialized_trim_strategy == THREE_READ_STRATEGY:
         return DEFAULT_THREE_READ_TRIM_STRATEGY
     else:
-        serialized_trim_coordinates = serialized_trim_strategy.strip().split()
+        serialized_trim_coordinates = serialized_trim_strategy.strip().split(',')
 
         if len(serialized_trim_coordinates) != 3:
             raise ValueError(

--- a/src/pgmap/cli.py
+++ b/src/pgmap/cli.py
@@ -6,7 +6,7 @@ from pgmap.counter import counter
 from pgmap.io import barcode_reader, library_reader, counts_writer
 from pgmap.trimming import read_trimmer
 from pgmap.model.trim_coordinate import TrimCoordinate
-from pgmap.model.trim_strategy import TrimStrategy
+from pgmap.model.trim_strategy import TrimStrategy, DEFAULT_TWO_READ_TRIM_STRATEGY, DEFAULT_THREE_READ_TRIM_STRATEGY
 
 TWO_READ_STRATEGY = "two-read"
 THREE_READ_STRATEGY = "three-read"
@@ -106,17 +106,9 @@ def _check_file_exists(path: str) -> str:
 
 def _check_trim_strategy(serialized_trim_strategy: str) -> TrimStrategy:
     if serialized_trim_strategy == TWO_READ_STRATEGY:
-        gRNA1_trim_coord = TrimCoordinate(file_index=0, start=0, end=20)
-        gRNA2_trim_coord = TrimCoordinate(file_index=1, start=1, end=21)
-        barcode_trim_coord = TrimCoordinate(file_index=1, start=160, end=166)
-
-        return TrimStrategy(gRNA1=gRNA1_trim_coord, gRNA2=gRNA2_trim_coord, barcode=barcode_trim_coord)
+        return DEFAULT_TWO_READ_TRIM_STRATEGY
     elif serialized_trim_strategy == THREE_READ_STRATEGY:
-        gRNA1_trim_coord = TrimCoordinate(file_index=0, start=0, end=20)
-        gRNA2_trim_coord = TrimCoordinate(file_index=1, start=1, end=21)
-        barcode_trim_coord = TrimCoordinate(file_index=2, start=0, end=6)
-
-        return TrimStrategy(gRNA1=gRNA1_trim_coord, gRNA2=gRNA2_trim_coord, barcode=barcode_trim_coord)
+        return DEFAULT_THREE_READ_TRIM_STRATEGY
     else:
         serialized_trim_coordinates = serialized_trim_strategy.strip().split()
 

--- a/src/pgmap/cli.py
+++ b/src/pgmap/cli.py
@@ -5,6 +5,8 @@ import sys
 from pgmap.counter import counter
 from pgmap.io import barcode_reader, library_reader, counts_writer
 from pgmap.trimming import read_trimmer
+from pgmap.model.trim_coordinate import TrimCoordinate
+from pgmap.model.trim_strategy import TrimStrategy
 
 TWO_READ_STRATEGY = "two-read"
 THREE_READ_STRATEGY = "three-read"
@@ -21,10 +23,7 @@ def get_counts(args: argparse.Namespace):
 
     candidate_reads = None
 
-    if args.trim_strategy == TWO_READ_STRATEGY:
-        candidate_reads = read_trimmer.two_read_trim(*args.fastq)
-    elif args.trim_strategy == THREE_READ_STRATEGY:
-        candidate_reads = read_trimmer.two_read_trim(*args.fastq)
+    candidate_reads = read_trimmer.trim(args.fastq, args.trim_strategy)
 
     paired_guide_counts = counter.get_counts(
         candidate_reads, gRNA_mappings, barcodes, gRNA1_error_tolerance=args.gRNA1_error, gRNA2_error_tolerance=args.gRNA2_error, barcode_error_tolerance=args.barcode_error)
@@ -47,9 +46,14 @@ def _parse_args(args: list[str]) -> argparse.Namespace:
     # TODO check can write to this path?
     parser.add_argument("-o", "--output", required=False,
                         help="Output file path to populate with the counts for each paired guide and sample. If not provided the counts will be output in STDOUT.")
-    # TODO support arbitrary trim strategies
-    parser.add_argument("--trim-strategy", required=True, choices=(TWO_READ_STRATEGY, THREE_READ_STRATEGY),
-                        help="The trim strategy used to extract guides and barcodes. The two read strategy should have fastqs R1 and I1. The three read strategy should have fastqs R1, I1, and I2")  # TODO extract consts
+    parser.add_argument("--trim-strategy", required=True, type=_check_trim_strategy,
+                        help="The trim strategy used to extract guides and barcodes. " +
+                             "A custom trim strategy should be formatted as as space separate list of trim coordinates for gRNA1, gRNA2, and the barcode. " +
+                             "Each trim coordinate should contain three zero indexed integers giving the file index relative to the order provided in --fastq, " +
+                             "the inclusive start index of the trim, and the exclusive end index of the trim. " +
+                             "For convenience the options \"two-read\" and \"three-read\" map to default values \"0:0:20 1:1:21 1:160:166\" and \"0:0:20 1:1:21 2:0:6\" respectively. " +
+                             "The two read strategy should have fastqs R1 and I1. " +
+                             "The three read strategy should have fastqs R1, I1, and I2.")
     parser.add_argument("--gRNA1-error", required=False, default=1, type=_check_gRNA1_error,
                         help="The number of substituted base pairs to allow in gRNA1. Must be less than 3.")
     parser.add_argument("--gRNA2-error", required=False, default=1, type=_check_gRNA2_error,
@@ -98,6 +102,50 @@ def _check_file_exists(path: str) -> str:
     else:
         raise argparse.ArgumentTypeError(
             f"File path {path} does not exist or is not readable")
+
+
+def _check_trim_strategy(serialized_trim_strategy: str) -> TrimStrategy:
+    if serialized_trim_strategy == TWO_READ_STRATEGY:
+        gRNA1_trim_coord = TrimCoordinate(file_index=0, start=0, end=20)
+        gRNA2_trim_coord = TrimCoordinate(file_index=1, start=1, end=21)
+        barcode_trim_coord = TrimCoordinate(file_index=1, start=160, end=166)
+
+        return TrimStrategy(gRNA1=gRNA1_trim_coord, gRNA2=gRNA2_trim_coord, barcode=barcode_trim_coord)
+    elif serialized_trim_strategy == THREE_READ_STRATEGY:
+        gRNA1_trim_coord = TrimCoordinate(file_index=0, start=0, end=20)
+        gRNA2_trim_coord = TrimCoordinate(file_index=1, start=1, end=21)
+        barcode_trim_coord = TrimCoordinate(file_index=2, start=0, end=6)
+
+        return TrimStrategy(gRNA1=gRNA1_trim_coord, gRNA2=gRNA2_trim_coord, barcode=barcode_trim_coord)
+    else:
+        serialized_trim_coordinates = serialized_trim_strategy.strip().split()
+
+        if len(serialized_trim_coordinates) != 3:
+            raise ValueError(
+                f"Trim strategy {serialized_trim_strategy} must provide three coordinates but had {len(serialized_trim_coordinates)} coordinates instead")
+
+        gRNA1_trim_coord, gRNA2_trim_coord, barcode_trim_coord = tuple(
+            map(_check_trim_coordinate, serialized_trim_coordinates))
+
+        return TrimStrategy(gRNA1=gRNA1_trim_coord, gRNA2=gRNA2_trim_coord, barcode=barcode_trim_coord)
+
+
+def _check_trim_coordinate(serialized_trim_coordinate: str) -> TrimCoordinate:
+    trim_indexes = serialized_trim_coordinate.split(":")
+
+    if len(trim_indexes) != 3:
+        raise ValueError(
+            f"Trim coordinate {serialized_trim_coordinate} must provide three indexes but had {len(serialized_trim_coordinate)} indexes instead")
+
+    file_index_str, start_str, end_str = trim_indexes
+
+    if not file_index_str.isdigit() or not start_str.isdigit() or not end_str.isdigit():
+        raise ValueError(
+            f"Trim coordinate {serialized_trim_coordinate} contained a non integer trim index")
+
+    file_index, start, end = tuple(map(int, trim_indexes))
+
+    return TrimCoordinate(file_index=file_index, start=start, end=end)
 
 
 if __name__ == "__main__":

--- a/src/pgmap/model/trim_strategy.py
+++ b/src/pgmap/model/trim_strategy.py
@@ -16,3 +16,16 @@ class TrimStrategy(typing.NamedTuple):
     gRNA1: TrimCoordinate
     gRNA2: TrimCoordinate
     barcode: TrimCoordinate
+
+
+DEFAULT_TWO_READ_TRIM_STRATEGY = TrimStrategy(
+    gRNA1=TrimCoordinate(file_index=0, start=0, end=20),
+    gRNA2=TrimCoordinate(file_index=1, start=1, end=21),
+    barcode=TrimCoordinate(file_index=1, start=160, end=166)
+)
+
+DEFAULT_THREE_READ_TRIM_STRATEGY = TrimStrategy(
+    gRNA1=TrimCoordinate(file_index=0, start=0, end=20),
+    gRNA2=TrimCoordinate(file_index=1, start=1, end=21),
+    barcode=TrimCoordinate(file_index=2, start=0, end=6)
+)

--- a/src/pgmap/trimming/read_trimmer.py
+++ b/src/pgmap/trimming/read_trimmer.py
@@ -2,7 +2,7 @@ from typing import Iterable
 
 from pgmap.io.fastx_reader import read_fastq
 from pgmap.model.trim_coordinate import TrimCoordinate
-from pgmap.model.trim_strategy import TrimStrategy
+from pgmap.model.trim_strategy import TrimStrategy, DEFAULT_TWO_READ_TRIM_STRATEGY, DEFAULT_THREE_READ_TRIM_STRATEGY
 from pgmap.model.paired_read import PairedRead
 
 
@@ -18,14 +18,7 @@ def two_read_trim(R1_path: str, I1_path: str, ) -> Iterable[PairedRead]:
         candidates (PairedRead): Trimmed paired reads.
     """
     # TODO include some kind of citation or link to the two read sequencing strategy?
-    gRNA1_trim_coord = TrimCoordinate(file_index=0, start=0, end=20)
-    gRNA2_trim_coord = TrimCoordinate(file_index=1, start=1, end=21)
-    barcode_trim_coord = TrimCoordinate(file_index=1, start=160, end=166)
-
-    trim_strategy = TrimStrategy(
-        gRNA1=gRNA1_trim_coord, gRNA2=gRNA2_trim_coord, barcode=barcode_trim_coord)
-
-    yield from trim([R1_path, I1_path], trim_strategy)
+    yield from trim([R1_path, I1_path], DEFAULT_TWO_READ_TRIM_STRATEGY)
 
 
 def three_read_trim(R1_path: str, R2_path: str, I1_path: str) -> Iterable[PairedRead]:
@@ -47,7 +40,7 @@ def three_read_trim(R1_path: str, R2_path: str, I1_path: str) -> Iterable[Paired
     trim_strategy = TrimStrategy(
         gRNA1=gRNA1_trim_coord, gRNA2=gRNA2_trim_coord, barcode=barcode_trim_coord)
 
-    yield from trim([R1_path, R2_path, I1_path], trim_strategy)
+    yield from trim([R1_path, R2_path, I1_path], DEFAULT_THREE_READ_TRIM_STRATEGY)
 
 
 def trim(fastq_paths: list[str], trim_strategy: TrimStrategy) -> Iterable[PairedRead]:

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -10,6 +10,8 @@ from pgmap.trimming import read_trimmer
 from pgmap.alignment import pairwise_aligner, grna_cached_aligner
 from pgmap.counter import counter
 from pgmap.model.paired_read import PairedRead
+from pgmap.model.trim_coordinate import TrimCoordinate
+from pgmap.model.trim_strategy import TrimStrategy
 from pgmap import cli
 
 THREE_READ_R1_PATH = "example-data/three-read-strategy/HeLa/PP_pgRNA_HeLa_S1_R1_001_Sampled10k.fastq.gz"
@@ -321,7 +323,12 @@ class TestPgmap(unittest.TestCase):
         self.assertEqual(args.fastq[1], TWO_READ_I1_PATH)
         self.assertEqual(args.library, PGPEN_ANNOTATION_PATH)
         self.assertEqual(args.barcodes, TWO_READ_BARCODES_PATH)
-        self.assertEqual(args.trim_strategy, "two-read")
+        gRNA1_trim_coord = TrimCoordinate(file_index=0, start=0, end=20)
+        gRNA2_trim_coord = TrimCoordinate(file_index=1, start=1, end=21)
+        barcode_trim_coord = TrimCoordinate(file_index=1, start=160, end=166)
+        two_read_trim_strategy = TrimStrategy(
+            gRNA1=gRNA1_trim_coord, gRNA2=gRNA2_trim_coord, barcode=barcode_trim_coord)
+        self.assertEqual(args.trim_strategy, two_read_trim_strategy)
         self.assertEqual(args.gRNA1_error, 1)
         self.assertEqual(args.gRNA1_error, 1)
         self.assertEqual(args.barcode_error, 1)
@@ -418,6 +425,34 @@ class TestPgmap(unittest.TestCase):
                                     "--trim-strategy", "two-read",
                                     "--barcode-error", "one"])
 
+    def test_arg_parse_length_greater_than_three_trim_strategy_error(self):
+        with self.assertRaises(argparse.ArgumentError):
+            args = cli._parse_args(["--fastq", TWO_READ_R1_PATH, TWO_READ_I1_PATH,
+                                    "--library", PGPEN_ANNOTATION_PATH,
+                                    "--barcodes", TWO_READ_BARCODES_PATH,
+                                    "--trim-strategy", "0:0:20 1:1:21 1:160:166 0:0:20 1:1:21 1:160:166"])
+
+    def test_arg_parse_invalid_length_zero_trim_strategy_error(self):
+        with self.assertRaises(argparse.ArgumentError):
+            args = cli._parse_args(["--fastq", TWO_READ_R1_PATH, TWO_READ_I1_PATH,
+                                    "--library", PGPEN_ANNOTATION_PATH,
+                                    "--barcodes", TWO_READ_BARCODES_PATH,
+                                    "--trim-strategy", ""])
+
+    def test_arg_parse_invalid_length_four_trim_coordinate_error(self):
+        with self.assertRaises(argparse.ArgumentError):
+            args = cli._parse_args(["--fastq", TWO_READ_R1_PATH, TWO_READ_I1_PATH,
+                                    "--library", PGPEN_ANNOTATION_PATH,
+                                    "--barcodes", TWO_READ_BARCODES_PATH,
+                                    "--trim-strategy", "0:0:20:2 1:1:21 1:160:166"])
+
+    def test_arg_parse_invalid_type_in_trim_coordinate_error(self):
+        with self.assertRaises(argparse.ArgumentError):
+            args = cli._parse_args(["--fastq", TWO_READ_R1_PATH, TWO_READ_I1_PATH,
+                                    "--library", PGPEN_ANNOTATION_PATH,
+                                    "--barcodes", TWO_READ_BARCODES_PATH,
+                                    "--trim-strategy", "one:0:20 1:1:21 1:160:166"])
+
     def setUp(self):
         self.test_output_path = f"test_file_{uuid.uuid4().hex}.tsv"
 
@@ -450,6 +485,51 @@ class TestPgmap(unittest.TestCase):
             self.test_output_path, barcodes)
 
         self.assertEqual(file_counts, paired_guide_counts)
+
+    def test_main_custom_trim_strategy(self):
+        args = cli._parse_args(["--fastq", TWO_READ_R1_PATH, TWO_READ_I1_PATH,
+                                "--library", PGPEN_ANNOTATION_PATH,
+                                "--barcodes", TWO_READ_BARCODES_PATH,
+                                "--output", self.test_output_path,
+                                "--trim-strategy", "0:0:20 1:1:21 1:160:165",  # trim barcode one off two-read
+                                "--barcode-error", "1"])
+        cli.get_counts(args)
+
+        self.assertTrue(os.path.exists(self.test_output_path))
+
+        barcodes = barcode_reader.read_barcodes(TWO_READ_BARCODES_PATH)
+
+        gRNA1s, gRNA2s, gRNA_mappings, id_mapping = library_reader.read_paired_guide_library_annotation(
+            PGPEN_ANNOTATION_PATH)
+
+        candidate_reads = read_trimmer.two_read_trim(
+            TWO_READ_R1_PATH, TWO_READ_I1_PATH)
+
+        paired_guide_counts = counter.get_counts(
+            candidate_reads, gRNA_mappings, barcodes)
+
+        file_counts = self.load_counts_from_output_file(
+            self.test_output_path, barcodes)
+
+        lte_count = 0
+        total_count = len(paired_guide_counts)
+
+        for k in paired_guide_counts:
+            # the test custom strategy trims barcodes off by one. the barcode error tolerance can compensate for this,
+            # but the custom trim should have less counts due to not tolerating read errors in addition to the missing end of the frame
+            if file_counts[k] <= paired_guide_counts[k]:
+                lte_count += 1
+
+        # sanity test that the misaligned read strategy still recovers most reads
+        self.assertGreater(sum(file_counts.values()) /
+                           sum(paired_guide_counts.values()), 0.5)
+
+        # but most paired guides should have less reads under the custom trim
+        self.assertGreater(lte_count / total_count, 0.99)
+
+        # finally check that they are not exactly equal
+        self.assertNotEqual(sum(file_counts.values()),
+                            sum(paired_guide_counts.values()))
 
     def load_counts_from_output_file(self, output_path: str, barcodes: dict[str, str]) -> Counter[tuple[str, str, str]]:
         with open(output_path, 'r') as file:


### PR DESCRIPTION
<!-- From https://axolo.co/blog/p/part-3-github-pull-request-template--> 

# Description

To make pgmap useful outside the Berger lab we need to support custom trim strategies. The support for this was already somewhat done, it just needed a CLI interface. What this does not support is support for more complex trimming and reading strategies such as staggered or paired end reads or reading in the reverse direction.

The CLI has basic sanity checks while parsing, but relies on downstream error handling for cases like indexes being out of bounds.

Working on documentation here: https://github.com/FredHutch/pgmap/pull/19


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Unit tests added. Run with `pip install . && python3 -m tests`. Also ran with `pgmap --fastq example-data/two-read-strategy/240123_VH01189_224_AAFGFNYM5/Undetermined_S0_R1_001_Sampled10k.fastq.gz example-data/two-read-strategy/240123_VH01189_224_AAFGFNYM5/Undetermined_S0_I1_001_Sampled10k.fastq.gz --library example-data/pgPEN-library/paralog_pgRNA_annotations.txt --barcodes example-data/two-read-strategy/240123_VH01189_224_AAFGFNYM5/barcode_ref_file_revcomp.txt --trim-strategy 0:0:20,1:1:21,1:160:166` and diffed with the two read strategy and saw no difference.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
