### PR TITLE
Clarify default error tolerances in CLI

### DIFF
--- a/src/pgmap/cli.py
+++ b/src/pgmap/cli.py
@@ -56,11 +56,11 @@ def _parse_args(args: list[str]) -> argparse.Namespace:
                              "The two read strategy should have fastqs R1 and I1. " +
                              "The three read strategy should have fastqs R1, I1, and I2.")
     parser.add_argument("--gRNA1-error", required=False, default=1, type=_check_gRNA1_error,
-                        help="The number of substituted base pairs to allow in gRNA1. Must be less than 3.")
+                        help="The number of substituted base pairs to allow in gRNA1. Must be less than 3. Defaults to 1.")
     parser.add_argument("--gRNA2-error", required=False, default=1, type=_check_gRNA2_error,
-                        help="The number of substituted base pairs to allow in gRNA2. Must be less than 3.")
+                        help="The number of substituted base pairs to allow in gRNA2. Must be less than 3. Defaults to 1.")
     parser.add_argument("--barcode-error", required=False, default=1, type=_check_barcode_error,
-                        help="The number of insertions, deletions, and subsititions of base pairs to allow in the barcodes.")
+                        help="The number of insertions, deletions, and subsititions of base pairs to allow in the barcodes. Defaults to 1.")
     return parser.parse_args(args)
 
 

--- a/src/pgmap/counter/counter.py
+++ b/src/pgmap/counter/counter.py
@@ -24,10 +24,12 @@ def get_counts(paired_reads: Iterable[PairedRead],
         gRNA_mappings (dict[str, set[str]]): The known mappings of each reference library gRNA1 to the set of gRNA2s
         the gRNA1 is paired with.
         barcodes (set[str]): The sample barcode sequences.
+        gRNA1_error_tolerance (int): The error tolerance for the hamming distance a gRNA1 candidate can be to the
+        reference gRNA1.
         gRNA2_error_tolerance (int): The error tolerance for the hamming distance a gRNA2 candidate can be to the
-        reference gRNA2. Defaults to 2.
+        reference gRNA2.
         barcode_error_tolerance (int): The error tolerance for the edit distance a barcode candidate can be to the
-        reference barcode. Defaults to 2.
+        reference barcode.
 
     Returns:
         paired_guide_counts (Counter[tuple[str, str, str]]): The counts of each (gRNA1, gRNA2, barcode) detected
@@ -35,7 +37,6 @@ def get_counts(paired_reads: Iterable[PairedRead],
     """
     # TODO should this keep track of metrics for how many paired reads get discarded and at which step? maybe with a verbose logging option?
     # TODO should we key with sample id instead of barcode sequence?
-    # TODO sanity test error tolerances on real data
     # TODO should alignment algorithm be user configurable?
 
     paired_guide_counts = Counter()


### PR DESCRIPTION
<!-- From https://axolo.co/blog/p/part-3-github-pull-request-template--> 

# Description

This just clarifies the help messages in the CLI to include the default values. This makes it consistent with the proposed README here: https://github.com/FredHutch/pgmap/pull/19

Tested for regression with `pip install . && python -m tests`
