### PR TITLE
Bump setuptools to prevent path traversal vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-Levenshtein==0.26.1
-setuptools==75.1.0
+setuptools>=78.1.1
 build==1.2.2.post1


### PR DESCRIPTION
Bumping setuptools version to address the vulnerability here: https://github.com/pypa/setuptools/issues/4946

No functional change and build and tests working
