### PR TITLE
Add support for quality control statistics output

### DIFF
--- a/src/pgmap/cli.py
+++ b/src/pgmap/cli.py
@@ -53,7 +53,7 @@ def _parse_args(args: list[str]) -> argparse.Namespace:
     parser.add_argument("-o", "--output", required=False,
                         help="Output file path to populate with the counts for each paired guide and sample. If not provided the counts will be output in STDOUT.")
     parser.add_argument("-q", "--quality-control", required=False,
-                        help="Output file path to populate with quality control statistics for the reads. If not provided quality control statistics will not be computed.")
+                        help="Quality control file path to populate with metadata and aggregate statistics about the data. If not provided quality control statistics will not be computed.")
     parser.add_argument("--trim-strategy", required=True, type=_check_trim_strategy,
                         help="The trim strategy used to extract guides and barcodes. " +
                              "A custom trim strategy should be formatted as as comma separate list of trim coordinates for gRNA1, gRNA2, and the barcode. " +

--- a/src/pgmap/counter/counter.py
+++ b/src/pgmap/counter/counter.py
@@ -81,7 +81,33 @@ def get_counts_and_qc_stats(paired_reads: Iterable[PairedRead],
                             gRNA1_error_tolerance: int = 1,
                             gRNA2_error_tolerance: int = 1,
                             barcode_error_tolerance: int = 1) -> tuple[Counter[tuple[str, str, str]], QualityControlStatistics]:
-    # TODO docs
+    """
+    Count paired guides for each sample barcode with tolerance for errors. gRNA1 matchs only through
+    perfect alignment. gRNA2 aligns if there is a match of a known (gRNA1, gRNA2) pairing having hamming distance
+    within the gRNA2 error tolerance. Finally the barcode aligns if there is a match aligned by edit distance
+    within a separate barcode error tolerance.
+
+    Additionally, compute quality control statistics for the reads. This function may be less efficient than
+    getting counts without quality control statistics due to the need to fully align all parts of a candidate read.
+
+    Args:
+        paired_reads (Iterable[PairedRead]): An iterable producing the candidate reads to be counted. Can be
+        generator to minimize memory usage.
+        gRNA_mappings (dict[str, set[str]]): The known mappings of each reference library gRNA1 to the set of gRNA2s
+        the gRNA1 is paired with.
+        barcodes (set[str]): The sample barcode sequences.
+        gRNA1_error_tolerance (int): The error tolerance for the hamming distance a gRNA1 candidate can be to the
+        reference gRNA1.
+        gRNA2_error_tolerance (int): The error tolerance for the hamming distance a gRNA2 candidate can be to the
+        reference gRNA2.
+        barcode_error_tolerance (int): The error tolerance for the edit distance a barcode candidate can be to the
+        reference barcode.
+
+    Returns:
+        paired_guide_counts (Counter[tuple[str, str, str]]): The counts of each (gRNA1, gRNA2, barcode) detected
+        within the paired reads.
+        quality_control_statistics (QualityControlStatistics): Quality control statistics for the paired reads.
+    """
     paired_guide_counts = Counter()
 
     total_reads = 0

--- a/src/pgmap/counter/counter.py
+++ b/src/pgmap/counter/counter.py
@@ -154,9 +154,8 @@ def get_counts_and_qc_stats(paired_reads: Iterable[PairedRead],
         total_reads += 1
 
     if total_reads == 0:
-        raise ValueError("Cannot compute QC statistics for reads with length 0.")
-
-    # TODO handle k = 1
+        raise ValueError(
+            "Cannot compute QC statistics for reads with length 0.")
 
     qc_stats = QualityControlStatistics(total_reads=total_reads,
                                         discard_rate=discard_count / total_reads,
@@ -168,11 +167,11 @@ def get_counts_and_qc_stats(paired_reads: Iterable[PairedRead],
                                         gRNA2_distance_mean=gRNA2_distance_mean,
                                         barcode_distance_mean=barcode_distance_mean,
                                         gRNA1_distance_variance=gRNA1_distance_sk /
-                                        (k - 1),
+                                        (k - 1) if k > 1 else 0,
                                         gRNA2_distance_variance=gRNA2_distance_sk /
-                                        (k - 1),
+                                        (k - 1) if k > 1 else 0,
                                         barcode_distance_variance=barcode_distance_sk /
-                                        (k - 1))
+                                        (k - 1) if k > 1 else 0)
 
     return paired_guide_counts, qc_stats
 

--- a/src/pgmap/counter/counter.py
+++ b/src/pgmap/counter/counter.py
@@ -3,6 +3,7 @@ from typing import Counter, Iterable
 import itertools
 
 from pgmap.model.paired_read import PairedRead
+from pgmap.model.quality_control_statistics import QualityControlStatistics
 from pgmap.alignment import pairwise_aligner, grna_cached_aligner
 
 
@@ -35,7 +36,6 @@ def get_counts(paired_reads: Iterable[PairedRead],
         paired_guide_counts (Counter[tuple[str, str, str]]): The counts of each (gRNA1, gRNA2, barcode) detected
         within the paired reads.
     """
-    # TODO should this keep track of metrics for how many paired reads get discarded and at which step? maybe with a verbose logging option?
     # TODO should we key with sample id instead of barcode sequence?
     # TODO should alignment algorithm be user configurable?
 
@@ -73,3 +73,69 @@ def get_counts(paired_reads: Iterable[PairedRead],
         paired_guide_counts[(gRNA1, gRNA2, barcode)] += 1
 
     return paired_guide_counts
+
+
+def get_counts_and_qc_stats(paired_reads: Iterable[PairedRead],
+                            gRNA_mappings: dict[str, set[str]],
+                            barcodes: set[str],
+                            gRNA1_error_tolerance: int = 1,
+                            gRNA2_error_tolerance: int = 1,
+                            barcode_error_tolerance: int = 1) -> tuple[Counter[tuple[str, str, str]], QualityControlStatistics]:
+    # TODO docs
+    paired_guide_counts = Counter()
+
+    total_reads = 0
+    discard_count = 0
+    gRNA1_mismatch_count = 0
+    gRNA2_mismatch_count = 0
+    barcode_mismatch_count = 0
+    estimated_recombination_count = 0
+
+    gRNA1_cached_aligner = grna_cached_aligner.construct_grna_error_alignment_cache(
+        gRNA_mappings.keys(), gRNA1_error_tolerance)
+
+    gRNA2_cached_aligner = grna_cached_aligner.construct_grna_error_alignment_cache(
+        set(itertools.chain.from_iterable(gRNA_mappings.values())), gRNA2_error_tolerance)
+
+    for paired_read in paired_reads:
+        paired_read.gRNA1_candidate
+
+        gRNA1, gRNA2, barcode = None, None, None
+        recombination = False
+
+        if paired_read.gRNA1_candidate in gRNA1_cached_aligner:
+            gRNA1, _ = gRNA1_cached_aligner[paired_read.gRNA1_candidate]
+        else:
+            gRNA1_mismatch_count += 1
+
+        if paired_read.gRNA2_candidate in gRNA2_cached_aligner:
+            gRNA2, _ = gRNA2_cached_aligner[paired_read.gRNA2_candidate]
+        else:
+            gRNA2_mismatch_count += 1
+
+        if gRNA1 and gRNA2 and gRNA2 not in gRNA_mappings[gRNA1]:
+            recombination = True
+            estimated_recombination_count += 1
+
+        barcode_score, barcode = max((pairwise_aligner.edit_distance_score(
+            paired_read.barcode_candidate, reference), reference) for reference in barcodes)
+
+        if (len(barcode) - barcode_score) > barcode_error_tolerance:
+            barcode_mismatch_count += 1
+            barcode = None
+
+        if gRNA1 and gRNA2 and barcode and not recombination:
+            paired_guide_counts[(gRNA1, gRNA2, barcode)] += 1
+        else:
+            discard_count += 1
+
+        total_reads += 1
+
+    qc_stats = QualityControlStatistics(total_reads=total_reads,
+                                        discard_rate=discard_count / total_reads,
+                                        gRNA1_mismatch_rate=gRNA1_mismatch_count / total_reads,
+                                        gRNA2_mismatch_rate=gRNA2_mismatch_count / total_reads,
+                                        barcode_mismatch_rate=barcode_mismatch_count / total_reads,
+                                        estimated_recombination_rate=estimated_recombination_count / total_reads)
+
+    return paired_guide_counts, qc_stats

--- a/src/pgmap/counter/counter.py
+++ b/src/pgmap/counter/counter.py
@@ -153,10 +153,10 @@ def get_counts_and_qc_stats(paired_reads: Iterable[PairedRead],
 
         total_reads += 1
 
-    # if total_reads == 0:
-    #     raise ValueError("Cannot compute QC statistics for reads with length 0.")
+    if total_reads == 0:
+        raise ValueError("Cannot compute QC statistics for reads with length 0.")
 
-    # TODO handle total reads 0 and k = 1
+    # TODO handle k = 1
 
     qc_stats = QualityControlStatistics(total_reads=total_reads,
                                         discard_rate=discard_count / total_reads,

--- a/src/pgmap/counter/counter.py
+++ b/src/pgmap/counter/counter.py
@@ -115,6 +115,7 @@ def get_counts_and_qc_stats(paired_reads: Iterable[PairedRead],
     gRNA1_mismatch_count = 0
     gRNA2_mismatch_count = 0
     barcode_mismatch_count = 0
+    gRNAs_align_count = 0
     estimated_recombination_count = 0
 
     # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
@@ -148,9 +149,12 @@ def get_counts_and_qc_stats(paired_reads: Iterable[PairedRead],
         else:
             gRNA2_mismatch_count += 1
 
-        if gRNA1 and gRNA2 and gRNA2 not in gRNA_mappings[gRNA1]:
-            recombination = True
-            estimated_recombination_count += 1
+        if gRNA1 and gRNA2:
+            gRNAs_align_count += 1
+
+            if gRNA2 not in gRNA_mappings[gRNA1]:
+                recombination = True
+                estimated_recombination_count += 1
 
         barcode_score, barcode = max((pairwise_aligner.edit_distance_score(
             paired_read.barcode_candidate, reference), reference) for reference in barcodes)
@@ -188,7 +192,7 @@ def get_counts_and_qc_stats(paired_reads: Iterable[PairedRead],
                                         gRNA1_mismatch_rate=gRNA1_mismatch_count / total_reads,
                                         gRNA2_mismatch_rate=gRNA2_mismatch_count / total_reads,
                                         barcode_mismatch_rate=barcode_mismatch_count / total_reads,
-                                        estimated_recombination_rate=estimated_recombination_count / total_reads,
+                                        estimated_recombination_rate=estimated_recombination_count / gRNAs_align_count,
                                         gRNA1_distance_mean=gRNA1_distance_mean,
                                         gRNA2_distance_mean=gRNA2_distance_mean,
                                         barcode_distance_mean=barcode_distance_mean,

--- a/src/pgmap/io/quality_control_statistics_writer.py
+++ b/src/pgmap/io/quality_control_statistics_writer.py
@@ -1,0 +1,13 @@
+import argparse
+import json
+from importlib.metadata import version
+
+from pgmap.model.quality_control_statistics import QualityControlStatistics
+
+
+def write_quality_control_statistics(cli_args: argparse.Namespace, qc_stats: QualityControlStatistics):
+    with open(cli_args.quality_control, 'w') as f:
+        qc_report = {"input": vars(cli_args), "version": version("pgmap")}
+        qc_report.update(qc_stats._asdict())
+
+        json.dump(qc_report, f, indent=4)

--- a/src/pgmap/model/quality_control_statistics.py
+++ b/src/pgmap/model/quality_control_statistics.py
@@ -17,3 +17,9 @@ class QualityControlStatistics(typing.NamedTuple):
     gRNA2_mismatch_rate: float
     barcode_mismatch_rate: float
     estimated_recombination_rate: float
+    gRNA1_distance_mean: float
+    gRNA2_distance_mean: float
+    barcode_distance_mean: float
+    gRNA1_distance_variance: float
+    gRNA2_distance_variance: float
+    barcode_distance_variance: float

--- a/src/pgmap/model/quality_control_statistics.py
+++ b/src/pgmap/model/quality_control_statistics.py
@@ -3,13 +3,29 @@ import typing
 
 class QualityControlStatistics(typing.NamedTuple):
     """
-    TODO docs
-    A single paired read containing a candidate for counting.
+    A summary of quality control statistics for candidate reads.
 
     Attributes:
-        gRNA1_candidate (str): The candidate gRNA1.
-        gRNA2_candidate (str): The candidate gRNA2.
-        barcode_candidate (str): The candidate barcode.
+        total_reads (int): The total amount of reads regardless of content.
+        discard_rate (float): The total rate from 0 to 1 of any kind of discarding of reads.
+        gRNA1_mismatch_rate (float): The rate at which gRNA1 candidates do not match a library gRNA1
+        allowing error tolerances.
+        gRNA2_mismatch_rate (float): The rate at which gRNA2 candidates do not match a library gRNA2
+        allowing error tolerances.
+        barcode_mismatch_rate (float): The rate at which barcode candidates do not match a library barcode
+        allowing error tolerances.
+        gRNA1_distance_mean (float): The mean distance that accepted gRNA1 candidates vary from the closest
+        library gRNA1.
+        gRNA2_distance_mean (float): The mean distance that accepted gRNA1 candidates vary from the closest
+        library gRNA2.
+        barcode_distance_mean (float): The mean distance that accepted barcode candidates vary from the closest
+        reference barcode.
+        gRNA1_distance_variance (float): The variance of the distances that accepted gRNA1 candidates vary from the closest
+        library gRNA1.
+        gRNA2_distance_variance (float): The variances of the distances that accepted gRNA2 candidates vary from the closest
+        library gRNA2.
+        barcode_distance_variance (float): The variances of the distances that accepted barcode candidates vary from the closest
+        reference barcode.
     """
     total_reads: int
     discard_rate: float

--- a/src/pgmap/model/quality_control_statistics.py
+++ b/src/pgmap/model/quality_control_statistics.py
@@ -14,18 +14,20 @@ class QualityControlStatistics(typing.NamedTuple):
         allowing error tolerances.
         barcode_mismatch_rate (float): The rate at which barcode candidates do not match a library barcode
         allowing error tolerances.
+        estimated_recombination_rate (float): The rate at which gRNA1 and gRNA2 candidates are aligned, but the
+        combination of gRNA1 and gRNA2 is not a valid pairing from the library.
         gRNA1_distance_mean (float): The mean distance that accepted gRNA1 candidates vary from the closest
         library gRNA1.
         gRNA2_distance_mean (float): The mean distance that accepted gRNA1 candidates vary from the closest
         library gRNA2.
         barcode_distance_mean (float): The mean distance that accepted barcode candidates vary from the closest
         reference barcode.
-        gRNA1_distance_variance (float): The variance of the distances that accepted gRNA1 candidates vary from the closest
-        library gRNA1.
-        gRNA2_distance_variance (float): The variances of the distances that accepted gRNA2 candidates vary from the closest
-        library gRNA2.
-        barcode_distance_variance (float): The variances of the distances that accepted barcode candidates vary from the closest
-        reference barcode.
+        gRNA1_distance_variance (float): The variance of the distances that accepted gRNA1 candidates vary
+        from the closest library gRNA1.
+        gRNA2_distance_variance (float): The variances of the distances that accepted gRNA2 candidates vary
+        from the closest library gRNA2.
+        barcode_distance_variance (float): The variances of the distances that accepted barcode candidates vary
+        from the closest reference barcode.
     """
     total_reads: int
     discard_rate: float

--- a/src/pgmap/model/quality_control_statistics.py
+++ b/src/pgmap/model/quality_control_statistics.py
@@ -1,0 +1,19 @@
+import typing
+
+
+class QualityControlStatistics(typing.NamedTuple):
+    """
+    TODO docs
+    A single paired read containing a candidate for counting.
+
+    Attributes:
+        gRNA1_candidate (str): The candidate gRNA1.
+        gRNA2_candidate (str): The candidate gRNA2.
+        barcode_candidate (str): The candidate barcode.
+    """
+    total_reads: int
+    discard_rate: float
+    gRNA1_mismatch_rate: float
+    gRNA2_mismatch_rate: float
+    barcode_mismatch_rate: float
+    estimated_recombination_rate: float

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -333,7 +333,7 @@ class TestPgmap(unittest.TestCase):
         self.assertEqual(qc_stats.gRNA1_mismatch_rate, 1 / 5)
         self.assertEqual(qc_stats.gRNA2_mismatch_rate, 1 / 5)
         self.assertEqual(qc_stats.barcode_mismatch_rate, 1 / 5)
-        self.assertEqual(qc_stats.estimated_recombination_rate, 1 / 5)
+        self.assertEqual(qc_stats.estimated_recombination_rate, 1 / 3)
         self.assertEqual(qc_stats.gRNA1_distance_mean, 1.0)
         self.assertEqual(qc_stats.gRNA2_distance_mean, 1.0)
         self.assertEqual(qc_stats.barcode_distance_mean, 0.5)

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,9 +1,11 @@
 import unittest
 import argparse
 import csv
+import json
 import os
 import uuid
 from collections import Counter
+from importlib.metadata import version
 
 from pgmap.io import barcode_reader, fastx_reader, library_reader
 from pgmap.trimming import read_trimmer
@@ -519,10 +521,14 @@ class TestPgmap(unittest.TestCase):
 
     def setUp(self):
         self.test_output_path = f"test_file_{uuid.uuid4().hex}.tsv"
+        self.test_qc_path = f"test_file_{uuid.uuid4().hex}.tsv"
 
     def tearDown(self):
         if os.path.exists(self.test_output_path):
             os.remove(self.test_output_path)
+
+        if os.path.exists(self.test_qc_path):
+            os.remove(self.test_qc_path)
 
     def test_main_happy_case(self):
         args = cli._parse_args(["--fastq", TWO_READ_R1_PATH, TWO_READ_I1_PATH,
@@ -626,6 +632,82 @@ class TestPgmap(unittest.TestCase):
         for k in paired_guide_counts:
             self.assertEqual(file_counts[k], paired_guide_counts[k])
 
+    def test_main_happy_case_with_quality_control(self):
+        args = cli._parse_args(["--fastq", TWO_READ_R1_PATH, TWO_READ_I1_PATH,
+                                "--library", PGPEN_ANNOTATION_PATH,
+                                "--barcodes", TWO_READ_BARCODES_PATH,
+                                "--output", self.test_output_path,
+                                "--quality-control", self.test_qc_path,
+                                "--trim-strategy", "two-read",
+                                "--gRNA1-error", "1",
+                                "--gRNA2-error", "1",
+                                "--barcode-error", "1"])
+        cli.get_counts(args)
+
+        self.assertTrue(os.path.exists(self.test_output_path))
+
+        barcodes = barcode_reader.read_barcodes(TWO_READ_BARCODES_PATH)
+
+        gRNA1s, gRNA2s, gRNA_mappings, id_mapping = library_reader.read_paired_guide_library_annotation(
+            PGPEN_ANNOTATION_PATH)
+
+        candidate_reads = read_trimmer.two_read_trim(
+            TWO_READ_R1_PATH, TWO_READ_I1_PATH)
+
+        paired_guide_counts, qc_stats = counter.get_counts_and_qc_stats(
+            candidate_reads, gRNA_mappings, barcodes)
+
+        file_counts = self.load_counts_from_output_file(
+            self.test_output_path, barcodes)
+
+        qc_output = self.load_qc_output(self.test_qc_path)
+
+        self.assertEqual(file_counts, paired_guide_counts)
+        self.assertEqual(qc_output["input"]["fastq"], [
+                         TWO_READ_R1_PATH, TWO_READ_I1_PATH])
+        self.assertEqual(qc_output["input"]["library"],
+                         PGPEN_ANNOTATION_PATH)
+        self.assertEqual(qc_output["input"]["barcodes"],
+                         TWO_READ_BARCODES_PATH)
+        self.assertEqual(qc_output["input"]["output"],
+                         self.test_output_path)
+        self.assertEqual(qc_output["input"]["quality_control"],
+                         self.test_qc_path)
+        self.assertEqual(qc_output["input"]["trim_strategy"],
+                         [[0, 0, 20], [1, 1, 21], [1, 160, 166]])
+        self.assertEqual(qc_output["input"]["gRNA1_error"],
+                         1)
+        self.assertEqual(qc_output["input"]["gRNA2_error"],
+                         1)
+        self.assertEqual(qc_output["input"]["barcode_error"],
+                         1)
+        self.assertEqual(qc_output["version"],
+                         version("pgmap"))
+        self.assertEqual(qc_output["total_reads"],
+                         qc_stats.total_reads)
+        self.assertEqual(qc_output["discard_rate"],
+                         qc_stats.discard_rate)
+        self.assertEqual(qc_output["gRNA1_mismatch_rate"],
+                         qc_stats.gRNA1_mismatch_rate)
+        self.assertEqual(qc_output["gRNA2_mismatch_rate"],
+                         qc_stats.gRNA2_mismatch_rate)
+        self.assertEqual(qc_output["barcode_mismatch_rate"],
+                         qc_stats.barcode_mismatch_rate)
+        self.assertEqual(qc_output["estimated_recombination_rate"],
+                         qc_stats.estimated_recombination_rate)
+        self.assertEqual(qc_output["gRNA1_distance_mean"],
+                         qc_stats.gRNA1_distance_mean)
+        self.assertEqual(qc_output["gRNA2_distance_mean"],
+                         qc_stats.gRNA2_distance_mean)
+        self.assertEqual(qc_output["barcode_distance_mean"],
+                         qc_stats.barcode_distance_mean)
+        self.assertEqual(qc_output["gRNA1_distance_variance"],
+                         qc_stats.gRNA1_distance_variance)
+        self.assertEqual(qc_output["gRNA2_distance_variance"],
+                         qc_stats.gRNA2_distance_variance)
+        self.assertEqual(qc_output["barcode_distance_variance"],
+                         qc_stats.barcode_distance_variance)
+
     def load_counts_from_output_file(self, output_path: str, barcodes: dict[str, str]) -> Counter[tuple[str, str, str]]:
         with open(output_path, 'r') as file:
             tsv_reader = csv.reader(file, delimiter='\t')
@@ -650,6 +732,10 @@ class TestPgmap(unittest.TestCase):
                     counts[(gRNA1, gRNA2, barcode)] += count
 
             return counts
+
+    def load_qc_output(self, qc_path: str) -> dict:
+        with open(qc_path, 'r') as file:
+            return json.load(file)
 
 
 if __name__ == "__main__":

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -311,7 +311,7 @@ class TestPgmap(unittest.TestCase):
                          "CCC": {"AAA"}}
         candidate_reads = [PairedRead("ACT", "GAA", "AAAA"), # gRNA2: 2 error
                            PairedRead("AGT", "CGG", "CCCA"), # gRNA1, gRNA2, barcode: 1 error
-                           PairedRead("ATT", "GAC", "TTTG"), # gRNA1, gRNA2, barcode: 1 error
+                           PairedRead("ATT", "GAC", "TTTT"), # gRNA1, gRNA2: 1 error. barcode: 0 error
                            PairedRead("CGG", "CAG", "TTCC"), # gRNA1: 2 error, barcode: 2 error
                            PairedRead("ACT", "CCC", "TTTT")] # no errors, but recombination
 
@@ -328,6 +328,12 @@ class TestPgmap(unittest.TestCase):
         self.assertEqual(qc_stats.gRNA2_mismatch_rate, 1 / 5)
         self.assertEqual(qc_stats.barcode_mismatch_rate, 1 / 5)
         self.assertEqual(qc_stats.estimated_recombination_rate, 1 / 5)
+        self.assertEqual(qc_stats.gRNA1_distance_mean, 1.0)
+        self.assertEqual(qc_stats.gRNA2_distance_mean, 1.0)
+        self.assertEqual(qc_stats.barcode_distance_mean, 0.5)
+        self.assertEqual(qc_stats.gRNA1_distance_variance, 0)
+        self.assertEqual(qc_stats.gRNA2_distance_variance, 0)
+        self.assertEqual(qc_stats.barcode_distance_variance, 1 / 4)
 
     # TODO separate these into own test module?
     def test_arg_parse_happy_case(self):

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -335,6 +335,16 @@ class TestPgmap(unittest.TestCase):
         self.assertEqual(qc_stats.gRNA2_distance_variance, 0)
         self.assertEqual(qc_stats.barcode_distance_variance, 1 / 4)
 
+    def test_counter_with_qc_empty_data(self):
+        barcodes = {"AAAA", "CCCC", "TTTT"}
+        gRNA_mappings = {"ACT": {"CAG", "GGC", "TTG"},
+                         "CCC": {"AAA"}}
+        candidate_reads = []
+
+        with self.assertRaises(ValueError):
+            paired_guide_counts, qc_stats = counter.get_counts_and_qc_stats(
+                candidate_reads, gRNA_mappings, barcodes)
+
     # TODO separate these into own test module?
     def test_arg_parse_happy_case(self):
         args = cli._parse_args(["--fastq", TWO_READ_R1_PATH, TWO_READ_I1_PATH,


### PR DESCRIPTION
# Description

Add qc statistics. See the changes to the readme for a full description of the statistics included

Addresses https://github.com/FredHutch/pgmap/issues/27

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

`pip install . && python3 -m tests`

Added unit tests for qc logic as well as end to end tests calling the CLI code.

Additionally manually tested with the example data using

`pgmap --fastq example-data/two-read-strategy/240123_VH01189_224_AAFGFNYM5/Undetermined_S0_R1_001_Sampled10k.fastq.gz \
example-data/two-read-strategy/240123_VH01189_224_AAFGFNYM5/Undetermined_S0_I1_001_Sampled10k.fastq.gz \
--library example-data/pgPEN-library/paralog_pgRNA_annotations.txt \
--barcodes example-data/two-read-strategy/240123_VH01189_224_AAFGFNYM5/barcode_ref_file_revcomp.txt \
--trim-strategy two-read --q qc.json && cat qc.json`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
